### PR TITLE
Hotfix/change param to resmarker info

### DIFF
--- a/workflows/resistance_marker_module.nf
+++ b/workflows/resistance_marker_module.nf
@@ -24,7 +24,7 @@ workflow RESISTANCE_MARKER_MODULE {
         resmarkers_amplicon = BUILD_RESMARKER_INFO.out.resmarker_info
     }
     else {
-        resmarkers_amplicon = params.resmarkers_amplicon
+        resmarkers_amplicon = params.resmarker_info
     }
 
     BUILD_RESISTANCE_TABLE(


### PR DESCRIPTION
resmarker info was incorrectly set to param called resmarker amplicon when users are overriding the building of resmarkers from the principal list. This fixes the assignment 